### PR TITLE
Enable EPEL in the CentOS-based postgres image

### DIFF
--- a/Dockerfile.anitya-postgres
+++ b/Dockerfile.anitya-postgres
@@ -3,7 +3,7 @@ MAINTAINER Slavek Kabrda <slavek@redhat.com>
 
 USER 0
 
-RUN yum install -y python-pip python-alembic python-psycopg2 python-zmq python-devel gcc libffi-devel openssl-devel
+RUN yum install -y epel-release && yum install -y python-pip python-alembic python-psycopg2 python-zmq python-devel gcc libffi-devel openssl-devel
 
 COPY files/run-postgresql /usr/bin/
 COPY files/postgres-post-init /usr/bin/


### PR DESCRIPTION
Needed for python-pip and others.