### PR TITLE
Create directory for storing files from maven-index-checker

### DIFF
--- a/Dockerfile.anitya-server
+++ b/Dockerfile.anitya-server
@@ -16,7 +16,9 @@ RUN pip install -r requirements.txt mod_wsgi
 ENV ANITYA_WEB_CONFIG /src/config.py
 RUN echo JAR_NAME = \'$(find /$INDEXER -name "$INDEXER-*-jar-with-dependencies.jar" | head -n 1)\' >> $ANITYA_WEB_CONFIG && \
     echo JAVA_PATH = \'/usr/bin/java\' >> $ANITYA_WEB_CONFIG && \
-    chmod a+rw $ANITYA_WEB_CONFIG
+    chmod a+rw $ANITYA_WEB_CONFIG && \
+    mkdir -p /src/target/central-index && \
+    chmod a+rw /src/target/central-index 
 
 EXPOSE 5000
 


### PR DESCRIPTION
This should fix issue #13. Cause of problem was that in Openshift, images are not run with a root privileges so we have to create directory where maven-index-checker stores its files (and give right permissions to it).