### PR TITLE
Query /api/distro/names in liveness probe

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -61,15 +61,15 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 60
-            timeoutSeconds: 6
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
-              path: /api/projects/names
+              path: /api/distro/names
               port: 5000
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 60
-            timeoutSeconds: 6
+            timeoutSeconds: 10
           resources:
             limits:
               memory: "512Mi"


### PR DESCRIPTION
/api/projects/names can yield too many results and thus can be slow

Also increase timeout to 10 seconds.